### PR TITLE
Docker configs for React deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+### STAGE 1: Build ###
+FROM node:10.0.0 as build
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+ENV PATH /usr/src/app/node_modules/.bin:$PATH
+COPY package.json /usr/src/app/package.json
+RUN npm install
+RUN npm install react-scripts -g
+COPY . /usr/src/app
+RUN npm run build
+
+### STAGE 2: Production Environment ###
+FROM nginx:1.15.5-alpine
+COPY --from=build /usr/src/app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  web:
+    build: .
+    image: dash-fronteend:0.1
+    ports:
+      - "80:80"
+    networks:
+      - dash-net
+networks:
+  dash-net:
+    external: true


### PR DESCRIPTION
Docker configurations to build a production-ready React app

`docker build ...` on Windows hangs, most likely due to large `node_modules/` directory. Adding `node_modules/` and `.git/` to .dockerignore fixes the issue